### PR TITLE
Add member-delimiter-style to typescript config

### DIFF
--- a/prettier.js
+++ b/prettier.js
@@ -3,5 +3,8 @@ module.exports = {
     "prettier",
     "prettier/flowtype",
     "prettier/react",
-  ]
+  ],
+  "rules": {
+    "typescript/member-delimiter-style": "off"
+  }
 }

--- a/typescript.js
+++ b/typescript.js
@@ -18,7 +18,10 @@ module.exports = {
       ],
       "rules": {
         "no-undef": "off",
-        "no-unused-vars": "off"
+        "no-unused-vars": "off",
+        "typescript/member-delimiter-style": [2, {
+          "delimiter": "none"
+        }]
       }
     }
   ]


### PR DESCRIPTION
---

Closes: #13 

---

### how to test
- in datatap using comma as a delimiter in typescript type declaration should throw an eslint error