### PR TITLE
Feature/15 16 17 new eslint features

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = {
             }
         },
         {
-            "files": ["**/stories.js"],
+            "files": ["**/stories/**", "**/stories.*"],
             "rules": {
                 "max-len": "off"
             }

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = {
     },
     "overrides": [
         {
-            "files": ["**/*.test.js"],
+            "files": ["**/*.test.js", "**/*.test.ts"],
             "env": {
                 "jest": true
             },

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ module.exports = {
         "jsx-a11y/no-static-element-interactions": "off",
         "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/mouse-events-have-key-events": "off",
+        "jsx-a11y/anchor-is-valid": "off",
 
         ////////// Imports //////////
 

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = {
     },
     "overrides": [
         {
-            "files": ["**/*.test.js", "**/*.test.ts"],
+            "files": ["**/*.test.(j|t)s"],
             "env": {
                 "jest": true
             },

--- a/index.js
+++ b/index.js
@@ -108,5 +108,25 @@ module.exports = {
 
         "import/no-extraneous-dependencies": ["error", {"devDependencies": true, "optionalDependencies": false}],
         "import/prefer-default-export": ["off"],
-    }
+    },
+    "overrides": [
+        {
+            "files": ["**/*.test.js"],
+            "env": {
+                "jest": true
+            },
+            "rules": {
+                "max-len": "off",
+                "no-unused-expressions": "off",
+                "no-useless-computed-key": "off", // flow does not support non-string property keys https://github.com/facebook/flow/issues/380
+                "react/no-find-dom-node": "off"
+            }
+        },
+        {
+            "files": ["**/stories.js"],
+            "rules": {
+                "max-len": "off"
+            }
+        }
+    ]
 }

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = {
         "indent": ["error", 4, { "SwitchCase": 1 }],
         "jsx-quotes": ["error", "prefer-double"],
         "padded-blocks": ["off", "never"],
-        "id-length": ["error", {"exceptions": ["b", "_"]}],
+        "id-length": ["error", {"exceptions": ["_", "x", "y", "z"]}],
         "new-cap": ["error", {
             "newIsCap": true,
             "capIsNew": false,

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = {
     },
     "overrides": [
         {
-            "files": ["**/*.test.(j|t)s"],
+            "files": ["**/*.test.*"],
             "env": {
                 "jest": true
             },

--- a/typescript.js
+++ b/typescript.js
@@ -19,7 +19,7 @@ module.exports = {
       "rules": {
         "no-undef": "off",
         "no-unused-vars": "off",
-        "react/prop-types": "off"
+        "react/prop-types": "off",
         "typescript/member-delimiter-style": [2, {
           "delimiter": "none"
         }]

--- a/typescript.js
+++ b/typescript.js
@@ -19,6 +19,7 @@ module.exports = {
       "rules": {
         "no-undef": "off",
         "no-unused-vars": "off",
+        "react/prop-types": "off"
         "typescript/member-delimiter-style": [2, {
           "delimiter": "none"
         }]


### PR DESCRIPTION
---

closes #15

---

**How to test (feature)**
(test in insights, datatap and adverity-components too)
- there should be no errors when using `x`, `y` and `z` as variables. but `b` should throw an eslint error now
- `anchor-is-valid` is off now, so it should be possible to use the `a` tag without `href`
- `react/prop-types` is off for typescript files (only datatap) so the code snippet from #16 should not throw an error. (test this globally, so outside of a component and inside a component's render function)
- the whole `overrides` is now in this eslint config too, so all configurations there should now work in all products. for this test, delete the same overrides part of the `.eslintrc` in our products. this is also a regression testing

**How to test (potential regressions)**
- no new errors should occur in all repos, besides that `b` is now too short.