### PR TITLE
Add disallow enums rule for typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,16 @@ module.exports = {
         "no-console": "error",
         "no-only-tests/no-only-tests": "error",
 
+        ////////// No Enums ////////////////
+
+        "no-restricted-syntax": [
+            "error",
+            {
+              "selector": "TSEnumDeclaration",
+              "message": "Don't declare enums"
+            }
+        ],
+
         ////////// Best Practices //////////
 
         "guard-for-in": "off",

--- a/index.js
+++ b/index.js
@@ -28,16 +28,6 @@ module.exports = {
         "no-console": "error",
         "no-only-tests/no-only-tests": "error",
 
-        ////////// No Enums ////////////////
-
-        "no-restricted-syntax": [
-            "error",
-            {
-              "selector": "TSEnumDeclaration",
-              "message": "Don't declare enums"
-            }
-        ],
-
         ////////// Best Practices //////////
 
         "guard-for-in": "off",

--- a/typescript.js
+++ b/typescript.js
@@ -22,6 +22,7 @@ module.exports = {
       "rules": {
         "consistent-return": "off",
         "default-case": "off",
+        "no-restricted-syntax": ["error", { "selector": "TSEnumDeclaration", "message": "Don't declare enums" }],
         "no-undef": "off",
         "no-unused-vars": "off",
         "react/prop-types": "off",


### PR DESCRIPTION
Close #34 

eslint rule to disallow enums type in typescript

Test:

Create a dependency on this branch in one of the following repositories
     nsights
     datatap
     presense
     adverity-components

 add `enum Test { 'one', 'two' }` to any `tsx` or `ts` file and do npm run lint (or npm run eslint, depending on the repo)
--> There should be eslint runtime error: `Don't declare enums`