### PR TITLE
Feature/38-ban-types-Number-String

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,21 +81,6 @@ module.exports = {
         "react/destructuring-assignment": ["off", "never"],
         "react/jsx-no-useless-fragment": "error",
 
-        ////////// Ban specific types ///////////
-
-        "@typescript-eslint/ban-types": ["error", {
-            "types": {
-                "Number": {
-                    "message": "Use number instead",
-                    "fixWith": "number"
-                },
-                "String": {
-                    "message": "Use string instead",
-                    "fixWith": "string"
-                }
-            }
-        }],
-
         ////////// A11Y //////////
 
         "jsx-a11y/no-noninteractive-element-interactions": "off",

--- a/index.js
+++ b/index.js
@@ -28,6 +28,16 @@ module.exports = {
         "no-console": "error",
         "no-only-tests/no-only-tests": "error",
 
+        ////////// No Enums ////////////////
+
+        "no-restricted-syntax": [
+            "error",
+            {
+              "selector": "TSEnumDeclaration",
+              "message": "Don't declare enums"
+            }
+        ],
+
         ////////// Best Practices //////////
 
         "guard-for-in": "off",
@@ -70,6 +80,21 @@ module.exports = {
         "react/forbid-prop-types": ["off"],
         "react/destructuring-assignment": ["off", "never"],
         "react/jsx-no-useless-fragment": "error",
+
+        ////////// Ban specific types ///////////
+
+        "@typescript-eslint/ban-types": ["error", {
+            "types": {
+                "Number": {
+                    "message": "Use number instead",
+                    "fixWith": "number"
+                },
+                "String": {
+                    "message": "Use string instead",
+                    "fixWith": "string"
+                }
+            }
+        }],
 
         ////////// A11Y //////////
 

--- a/index.js
+++ b/index.js
@@ -28,16 +28,6 @@ module.exports = {
         "no-console": "error",
         "no-only-tests/no-only-tests": "error",
 
-        ////////// No Enums ////////////////
-
-        "no-restricted-syntax": [
-            "error",
-            {
-              "selector": "TSEnumDeclaration",
-              "message": "Don't declare enums"
-            }
-        ],
-
         ////////// Best Practices //////////
 
         "guard-for-in": "off",

--- a/typescript.js
+++ b/typescript.js
@@ -32,7 +32,19 @@ module.exports = {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "error",
         "@typescript-eslint/no-require-imports": "error",
-        "@typescript-eslint/no-unused-vars": ["error", { args: "after-used", argsIgnorePattern: "[iI]gnored$" }]
+        "@typescript-eslint/no-unused-vars": ["error", { args: "after-used", argsIgnorePattern: "[iI]gnored$" }],
+        "@typescript-eslint/ban-types": ["error", {
+          "types": {
+              "Number": {
+                  "message": "Use number instead",
+                  "fixWith": "number"
+              },
+              "String": {
+                  "message": "Use string instead",
+                  "fixWith": "string"
+              }
+          }
+      }],
       }
     }
   ]

--- a/typescript.js
+++ b/typescript.js
@@ -26,6 +26,7 @@ module.exports = {
         "no-unused-vars": "off",
         "react/prop-types": "off",
         "@typescript-eslint/array-type": ["error", { default: "generic", readonly: "generic" }],
+        "@typescript-eslint/ban-types": "error",
         "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/consistent-type-definitions": ["error", "type"],
         "@typescript-eslint/explicit-function-return-type": "off",
@@ -33,18 +34,6 @@ module.exports = {
         "@typescript-eslint/no-non-null-assertion": "error",
         "@typescript-eslint/no-require-imports": "error",
         "@typescript-eslint/no-unused-vars": ["error", { args: "after-used", argsIgnorePattern: "[iI]gnored$" }],
-        "@typescript-eslint/ban-types": ["error", {
-          "types": {
-              "Number": {
-                  "message": "Use number instead",
-                  "fixWith": "number"
-              },
-              "String": {
-                  "message": "Use string instead",
-                  "fixWith": "string"
-              }
-          }
-      }],
       }
     }
   ]

--- a/typescript.js
+++ b/typescript.js
@@ -23,6 +23,7 @@ module.exports = {
         "consistent-return": "off",
         "default-case": "off",
         "no-undef": "off",
+        "no-unused-expressions": "off",
         "no-unused-vars": "off",
         "react/prop-types": "off",
         "@typescript-eslint/array-type": ["error", { default: "generic", readonly: "generic" }],
@@ -33,6 +34,7 @@ module.exports = {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "error",
         "@typescript-eslint/no-require-imports": "error",
+        "@typescript-eslint/no-unused-expressions": "error",
         "@typescript-eslint/no-unused-vars": ["error", { args: "after-used", argsIgnorePattern: "[iI]gnored$" }],
       }
     }


### PR DESCRIPTION
Close #38 

eslint rule to disallow `Number` and `String` type in typescript

Test:

Create a dependency on this branch in one of the following repositories
nsights
datatap
presense
adverity-components

add 
    `type TestString = String`
    `type TestNumber = Number`

to any `tsx` or `ts` file and do npm run lint (or npm run eslint, depending on the repo)
--> There should be eslint runtime errors:
`Don't use 'String' as a type. Use string instead `
`Don't use 'Number' as a type. Use number instead `