### PR TITLE
chore: bump eslint-config-airbnb to 18.1.0

### DIFF
--- a/.changeset/75-upgrade-eslint-config-airbnb.md
+++ b/.changeset/75-upgrade-eslint-config-airbnb.md
@@ -1,0 +1,6 @@
+---
+issue: https://github.com/pmedianetwork/eslint-config/issues/75
+type: patch
+---
+
+Turn off `label-has-for` rule by upgrading eslint-config-airbnb package to 18.1.0.

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -129,4 +129,4 @@ const customRules = {
 }
 
 module.exports.baseRecommendedConfig = baseRecommendedConfig
-module.exports.recommended = Object.assign({}, baseRecommendedConfig, customRules)
+module.exports.recommended = { ...baseRecommendedConfig, ...customRules }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2217,23 +2217,23 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
-      "integrity": "sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.1.0.tgz",
+      "integrity": "sha512-kZFuQC/MPnH7KJp6v95xsLBf63G/w7YqdPfQ0MUanxQ7zcKUNG8j+sSY860g3NwCBOa62apw16J6pRN+AOgXzw==",
       "requires": {
-        "eslint-config-airbnb-base": "^13.2.0",
+        "eslint-config-airbnb-base": "^14.1.0",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.1.1"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-      "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz",
+      "integrity": "sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==",
       "requires": {
-        "confusing-browser-globals": "^1.0.5",
+        "confusing-browser-globals": "^1.0.9",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.1.1"
       }
     },
     "eslint-config-prettier": {

--- a/package.json
+++ b/package.json
@@ -1,49 +1,49 @@
 {
-  "name": "@pmedianetwork/eslint-plugin",
-  "version": "4.2.0",
-  "description": "Shared ESLint config for pmedianetwork projects.",
-  "author": "pmedianetwork",
-  "main": "index.js",
-  "scripts": {
-    "test": "jest --watch",
-    "lint": "eslint tests/**/*.js lib/**/*.js index.js",
-    "lint:fix": "npm run lint -- --fix"
-  },
-  "dependencies": {
-    "eslint-module-utils": "2.5.2",
-    "@typescript-eslint/eslint-plugin": "2.10.0",
-    "@typescript-eslint/parser": "2.10.0",
-    "babel-eslint": "10.0.3",
-    "eslint": "6.7.2",
-    "eslint-config-airbnb": "17.1.1",
-    "eslint-config-prettier": "6.0.0",
-    "eslint-import-resolver-typescript": "1.1.1",
-    "eslint-import-resolver-webpack": "0.11.1",
-    "eslint-plugin-flowtype": "3.12.2",
-    "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-jsx-a11y": "6.2.3",
-    "eslint-plugin-no-only-tests": "2.3.1",
-    "eslint-plugin-prettier": "3.1.2",
-    "eslint-plugin-react": "7.16.0",
-    "eslint-plugin-react-hooks": "2.2.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint",
-      "pre-push": "jest"
+    "name": "@pmedianetwork/eslint-plugin",
+    "version": "4.2.0",
+    "description": "Shared ESLint config for pmedianetwork projects.",
+    "author": "pmedianetwork",
+    "main": "index.js",
+    "scripts": {
+        "test": "jest --watch",
+        "lint": "eslint tests/**/*.js lib/**/*.js index.js",
+        "lint:fix": "npm run lint -- --fix"
+    },
+    "dependencies": {
+        "eslint-module-utils": "2.5.2",
+        "@typescript-eslint/eslint-plugin": "2.10.0",
+        "@typescript-eslint/parser": "2.10.0",
+        "babel-eslint": "10.0.3",
+        "eslint": "6.7.2",
+        "eslint-config-airbnb": "18.1.0",
+        "eslint-config-prettier": "6.0.0",
+        "eslint-import-resolver-typescript": "1.1.1",
+        "eslint-import-resolver-webpack": "0.11.1",
+        "eslint-plugin-flowtype": "3.12.2",
+        "eslint-plugin-import": "2.18.2",
+        "eslint-plugin-jsx-a11y": "6.2.3",
+        "eslint-plugin-no-only-tests": "2.3.1",
+        "eslint-plugin-prettier": "3.1.2",
+        "eslint-plugin-react": "7.16.0",
+        "eslint-plugin-react-hooks": "2.2.0"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "npm run lint",
+            "pre-push": "jest"
+        }
+    },
+    "devDependencies": {
+        "husky": "4.2.3",
+        "jest": "25.1.0",
+        "prettier": "1.19.1"
+    },
+    "license": "MIT",
+    "prettier": {
+        "printWidth": 120,
+        "semi": false,
+        "singleQuote": true,
+        "trailingComma": "all",
+        "tabWidth": 4
     }
-  },
-  "devDependencies": {
-    "husky": "4.2.3",
-    "jest": "25.1.0",
-    "prettier": "1.19.1"
-  },
-  "license": "MIT",
-  "prettier": {
-    "printWidth": 120,
-    "semi": false,
-    "singleQuote": true,
-    "trailingComma": "all",
-    "tabWidth": 4
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pmedianetwork/eslint-plugin",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "description": "Shared ESLint config for pmedianetwork projects.",
     "author": "pmedianetwork",
     "main": "index.js",


### PR DESCRIPTION
---

Closes #75 

---

I have upgraded `eslint-config-airbnb` package to its newest version. It deprecates the rule mentioned in the linked issue.